### PR TITLE
Issue #70 Instantiate action controllers through Mage::getModel

### DIFF
--- a/app/code/community/Segment/Analytics/Model/Front/Controller.php
+++ b/app/code/community/Segment/Analytics/Model/Front/Controller.php
@@ -13,11 +13,17 @@ class Segment_Analytics_Model_Front_Controller
     {
         if(!self::$_instance)
         {
-            self::$_instance = new Segment_Analytics_Model_Front_Controller;
+            self::$_instance = Mage::getSingleton('segment_analytics/front_controller');
         }
         return self::$_instance;
     }
-        
+    
+    protected function _controllerFactory($actionName)
+    {
+        $model = 'segment_analytics/controller_' . $actionName;
+        return Mage::getModel($model);
+    }
+    
     public function addDeferredAction($action, $action_data=array())
     {
         Mage::Log("Adding Deferred Action $action");
@@ -69,8 +75,7 @@ class Segment_Analytics_Model_Front_Controller
         $blocks[] = array();
         foreach($this->_actions as $action)
         {
-            $class = 'Segment_Analytics_Model_Controller_' . ucwords($action);
-            $controller = new $class;
+            $controller = $this->_controllerFactory($action);
             $controller->setName($action)
             ->setData($this->_actionsData[$action]);
             $blocks[$action][] = $controller->dispatch();
@@ -78,8 +83,7 @@ class Segment_Analytics_Model_Front_Controller
         
         foreach($this->getDeferredActions() as $action)
         {
-            $class = 'Segment_Analytics_Model_Controller_' . ucwords($action->action);
-            $controller = new $class;
+            $controller = $this->_controllerFactory($action->action);
             $controller->setName($action->action)
             ->setData($action->data);
             $blocks[$action->action][] = $controller->dispatch();        


### PR DESCRIPTION
Now using `Mage::getModel('segment_analytics/controller_' . $actionName)` to instantiate action controllers instead of instantiating them directly so the controller classes (models) can be rewritten through the core Magento rewrite system.

I've done this by adding a factory method. I also changed the Front Controller model from instantiating it directly to doing this through `Mage::getSingleton()`. This way you could also rewrite the Front Controller model and ultimately rewrite the behaviour of the new `Segment_Analytics_Model_Front_Controller::_controllerFactory()` method to first try to find custom action controllers somewhere else for instance (= some sort of fallback).

See issue #70 